### PR TITLE
Fixed overlay flickering while dragging handle

### DIFF
--- a/src/TwentyTwenty.vue
+++ b/src/TwentyTwenty.vue
@@ -1,20 +1,21 @@
 <template>
   <div class="twentytwenty-container"
-    v-bind:style="containerStyle"
-    v-on:touchstart="startSlide"
-    v-on:mousedown="startSlide">
+    v-bind:style="containerStyle">
     <img :src="after" alt="after"
       v-on:mousedown.prevent
       v-on:load="setDimensions" />
     <img :src="before" alt="before"
       v-on:mousedown.prevent
       v-bind:style="beforeImgStyle" />
-    <div class="twentytwenty-overlay">
+    <div class="twentytwenty-overlay"
+      v-bind:style="overlayStyle">
       <div v-if="beforeLabel" class="twentytwenty-before-label">{{beforeLabel}}</div>
       <div v-if="afterLabel" class="twentytwenty-after-label">{{afterLabel}}</div>
     </div>
     <div class="twentytwenty-handle"
-      v-bind:style="handleStyle">
+      v-bind:style="handleStyle"
+      v-on:touchstart="startSlide"
+      v-on:mousedown="startSlide">
         <div class="twentytwenty-arrow-left"></div>
         <div class="twentytwenty-arrow-right"></div>
     </div>
@@ -28,7 +29,8 @@ export default {
       imgOffset: null,
       slideOffset: this.offset,
       sliding: false,
-      containerStyle: {}
+      containerStyle: {},
+      overlayStyle: {}
     }
   },
 
@@ -66,6 +68,7 @@ export default {
     startSlide (event) {
       this.sliding = true
       this.moveSlide(event)
+      this.overlayStyle = { opacity: 0 }
     },
 
     moveSlide (event) {
@@ -77,7 +80,10 @@ export default {
       }
     },
 
-    endSlide () { this.sliding = false },
+    endSlide () {
+      this.sliding = false
+      this.overlayStyle = {}
+    },
 
     resize () {
       this.containerStyle = {};
@@ -175,7 +181,7 @@ export default {
 .twentytwenty-container .twentytwenty-overlay .twentytwenty-after-label {
   right: 0;
 }
-.twentytwenty-container .twentytwenty-overlay:hover {
+.twentytwenty-container:hover > .twentytwenty-overlay {
   opacity: 1;
 }
 .twentytwenty-container .twentytwenty-handle {


### PR DESCRIPTION
When dragging the handle, the .twentytwenty-overlay previously faded in and out as soon as the mouse left the handle div. Now, the hover class is applied to the .twentytwenty-container directly and gets overwritten at the startSlide() event. Also, v-on:touchstart="startSlide" and v-on:mousedown="startSlide" were moved from the .twentytwenty-overlay to the .twentytwenty-handle to create a user experience more consistent with the original [TwentyTwenty plugin](http://zurb.com/playground/twentytwenty).